### PR TITLE
Fix IllegalArgumentException for ping event?

### DIFF
--- a/pistonmotd-bukkit/src/main/java/me/alexprogrammerde/pistonmotd/bukkit/PingEventPaper.java
+++ b/pistonmotd-bukkit/src/main/java/me/alexprogrammerde/pistonmotd/bukkit/PingEventPaper.java
@@ -17,6 +17,7 @@ import org.bukkit.event.Listener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class PingEventPaper implements Listener {
@@ -63,12 +64,9 @@ public class PingEventPaper implements Listener {
             }
         } else if (config.getBoolean("extended.playercounter.activated")) {
             event.getPlayerSample().clear();
-
-            int i = 0;
-
+            
             for (String str : config.getStringList("extended.playercounter.text")) {
-                event.getPlayerSample().add(i, Bukkit.createProfile(PlaceholderUtil.parseText(str)));
-                i++;
+                event.getPlayerSample().add(Bukkit.createProfile(UUID.randomUUID(), PlaceholderUtil.parseText(str)));
             }
         }
 


### PR DESCRIPTION
Not 100% confident that this will fix it.
Please **do tests before merging this**!

I essentially replaced the `createProfile` method with the one requiring a UUID and use the `UUID.randomUUID()` to handle this one.
Hopefully this will fix the issue I mentioned in #1

Also, note that as stated in https://github.com/AlexProgrammerDE/PistonMOTD/issues/1#issuecomment-731644584 does the playercounter still get modified despite having the "activated" method disabled. This should be looked into.