### PR TITLE
sponge: Consider all metrics collection states

### DIFF
--- a/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/JoinEvent.java
+++ b/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/JoinEvent.java
@@ -5,6 +5,7 @@ import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.util.Tristate;
 
 public class JoinEvent {
     private final PistonMOTDSponge plugin;
@@ -17,7 +18,7 @@ public class JoinEvent {
     public void onJoin(ClientConnectionEvent temp) {
         if (temp instanceof ClientConnectionEvent.Join) {
             ClientConnectionEvent.Join event = (ClientConnectionEvent.Join) temp;
-            if (event.getTargetEntity().hasPermission("sponge.command.metrics") && !plugin.hasConsent()) {
+            if (event.getTargetEntity().hasPermission("sponge.command.metrics") && plugin.getEffectiveCollectionState() == Tristate.UNDEFINED) {
                 event.getTargetEntity().sendMessage(Text.builder("-----[ PistonMOTD ]-----").color(TextColors.GOLD).onClick(TextActions.runCommand("/sponge metrics pistonmotd enable")).build());
                 event.getTargetEntity().sendMessage(Text.builder("Hey there! It seems like data collection is disabled. :( ").color(TextColors.GOLD).onClick(TextActions.runCommand("/sponge metrics pistonmotd enable")).build());
                 event.getTargetEntity().sendMessage(Text.builder("But don't worry... You can fix this! ").color(TextColors.GOLD).onClick(TextActions.runCommand("/sponge metrics pistonmotd enable")).build());

--- a/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/PistonMOTDSponge.java
+++ b/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/PistonMOTDSponge.java
@@ -27,6 +27,7 @@ import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.metric.MetricsConfigManager;
 
 import java.io.File;
@@ -140,10 +141,11 @@ public class PistonMOTDSponge {
             }));
         }
 
-        if (hasConsent()) {
+        final Tristate collectionState = this.getEffectiveCollectionState();
+        if (collectionState == Tristate.TRUE) {
             log.info(ConsoleColor.CYAN + "Loading metrics" + ConsoleColor.RESET);
             metricsFactory.make(9204);
-        } else {
+        } else if (collectionState == Tristate.UNDEFINED) {
             log.info(ConsoleColor.CYAN + "Hey there! It seems like data collection is disabled. :( " + ConsoleColor.RESET);
             log.info(ConsoleColor.CYAN + "But don't worry... You can fix this! " + ConsoleColor.RESET);
             log.info(ConsoleColor.CYAN + "Just execute: \"/sponge metrics pistonmotd enable\"." + ConsoleColor.RESET);
@@ -196,7 +198,19 @@ public class PistonMOTDSponge {
         }
     }
 
-    protected boolean hasConsent() {
-        return metricsConfigManager.getCollectionState(this.container).asBoolean();
+    /**
+     * Gets the effective collection state for the plugin.
+     * <p>
+     * This will return the global collection state fallback, if the server administrator doesn't
+     * have a specific collection state for the plugin.
+     *
+     * @return The collection state
+     */
+    protected Tristate getEffectiveCollectionState() {
+        final Tristate pluginState = this.metricsConfigManager.getCollectionState(this.container);
+        if (pluginState == Tristate.UNDEFINED) {
+            return this.metricsConfigManager.getGlobalCollectionState();
+        }
+        return pluginState;
     }
 }


### PR DESCRIPTION
SpongeAPI has 3 potential collection states that a plugin can
effectively have:
1. TRUE -> The server administrator has explicitly enabled metrics for
   either the plugin, or the server globally.
2. FALSE -> The server administrator has explicitly disabled metrics
   for either the plugin, or the server globally.
3. UNDEFINED -> The server administrator has set neither a plugin or
   global collection state. This defaults to metrics being disabled.

If a server administrator has explicitly or implicitly disabled
metrics globally, it is still possible that metrics may be enabled for
a plugin - through its own collection state, which has a higher
precedence when establishing the effective collection state.

This also works conversely - its entirely possible that a global state
could be TRUE, but a plugin's effective state is still FALSE - if the
server administrator has explicitly disabled metrics for that plugin.
