### PR TITLE
Fixed spelling error when starting server

### DIFF
--- a/pistonmotd-bukkit/src/main/java/net/pistonmaster/pistonmotd/bukkit/PistonMOTDBukkit.java
+++ b/pistonmotd-bukkit/src/main/java/net/pistonmaster/pistonmotd/bukkit/PistonMOTDBukkit.java
@@ -78,7 +78,7 @@ public class PistonMOTDBukkit extends JavaPlugin {
         log.info(ChatColor.AQUA + "Checking for a newer version");
         new UpdateChecker(new PistonLogger(getLogger())).getVersion("https://www.pistonmaster.net/PistonMOTD/VERSION.txt", version -> new UpdateParser(getDescription().getVersion(), version).parseUpdate(updateType -> {
             if (updateType == UpdateType.NONE || updateType == UpdateType.AHEAD) {
-                log.info(ChatColor.AQUA + "Your up to date!");
+                log.info(ChatColor.AQUA + "You're up to date!");
             } else {
                 if (updateType == UpdateType.MAJOR) {
                     log.info(ChatColor.RED + "There is a MAJOR update available!");

--- a/pistonmotd-bungee/src/main/java/net/pistonmaster/pistonmotd/bungee/PistonMOTDBungee.java
+++ b/pistonmotd-bungee/src/main/java/net/pistonmaster/pistonmotd/bungee/PistonMOTDBungee.java
@@ -78,7 +78,7 @@ public class PistonMOTDBungee extends Plugin {
         log.info(ChatColor.AQUA + "Checking for a newer version");
         new UpdateChecker(new PistonLogger(getLogger())).getVersion("https://www.pistonmaster.net/PistonMOTD/VERSION.txt", version -> new UpdateParser(getDescription().getVersion(), version).parseUpdate(updateType -> {
             if (updateType == UpdateType.NONE || updateType == UpdateType.AHEAD) {
-                log.info(ChatColor.AQUA + "Your up to date!");
+                log.info(ChatColor.AQUA + "You're up to date!");
             } else {
                 if (updateType == UpdateType.MAJOR) {
                     log.info(ChatColor.RED + "There is a MAJOR update available!");

--- a/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/PistonMOTDSponge.java
+++ b/pistonmotd-sponge/src/main/java/net/pistonmaster/pistonmotd/sponge/PistonMOTDSponge.java
@@ -125,7 +125,7 @@ public class PistonMOTDSponge {
             log.info(ConsoleColor.CYAN + "Checking for a newer version" + ConsoleColor.RESET);
             new UpdateChecker(new PistonLogger(log)).getVersion("https://www.pistonmaster.net/PistonMOTD/VERSION.txt", version -> new UpdateParser(container.getVersion().get(), version).parseUpdate(updateType -> {
                 if (updateType == UpdateType.NONE || updateType == UpdateType.AHEAD) {
-                    log.info(ConsoleColor.CYAN + "Your up to date!" + ConsoleColor.RESET);
+                    log.info(ConsoleColor.CYAN + "You're up to date!" + ConsoleColor.RESET);
                 } else {
                     if (updateType == UpdateType.MAJOR) {
                         log.info(ConsoleColor.RED + "There is a MAJOR update available!" + ConsoleColor.RESET);

--- a/pistonmotd-velocity/src/main/java/net/pistonmaster/pistonmotd/velocity/PistonMOTDVelocity.java
+++ b/pistonmotd-velocity/src/main/java/net/pistonmaster/pistonmotd/velocity/PistonMOTDVelocity.java
@@ -82,7 +82,7 @@ public class PistonMOTDVelocity {
             log.info(ConsoleColor.CYAN + "Checking for a newer version" + ConsoleColor.RESET);
             new UpdateChecker(new PistonLogger(log)).getVersion("https://www.pistonmaster.net/PistonMOTD/VERSION.txt", version -> new UpdateParser(container.getDescription().getVersion().get(), version).parseUpdate(updateType -> {
                 if (updateType == UpdateType.NONE || updateType == UpdateType.AHEAD) {
-                    log.info(ConsoleColor.CYAN + "Your up to date!" + ConsoleColor.RESET);
+                    log.info(ConsoleColor.CYAN + "You're up to date!" + ConsoleColor.RESET);
                 } else {
                     if (updateType == UpdateType.MAJOR) {
                         log.info(ConsoleColor.RED + "There is a MAJOR update available!" + ConsoleColor.RESET);


### PR DESCRIPTION
When starting my server with this plugin installed I couldn't help notice that 'your' was spelt wrong in the alert message after checking current plugin version, so I fixed it.

Changed 'Your up to date!' to 'You're up to date!' in all versions of the plugin.