### PR TITLE
fix: [Feature] [Medium] Support for Wildcards on Hostnames

### DIFF
--- a/shared/src/main/java/net/pistonmaster/pistonmotd/shared/utils/HostnameUtils.java
+++ b/shared/src/main/java/net/pistonmaster/pistonmotd/shared/utils/HostnameUtils.java
@@ -1,0 +1,28 @@
+package net.pistonmaster.pistonmotd.shared.utils;
+
+import java.util.regex.Pattern;
+
+public final class HostnameUtils {
+  private HostnameUtils() {
+  }
+
+  /**
+   * Checks if a hostname matches a given pattern.
+   * Supports wildcards using '*' (e.g., '*.example.com').
+   *
+   * @param hostname The hostname to check.
+   * @param pattern  The pattern to match against.
+   * @return true if the hostname matches the pattern.
+   */
+  public static boolean matches(String hostname, String pattern) {
+    if (hostname == null || pattern == null) {
+      return false;
+    }
+    if (hostname.equals(pattern)) {
+      return true;
+    }
+    String regex = pattern.replace(".", "\\.");
+    regex = regex.replace("*", ".*");
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(hostname).matches();
+  }
+}


### PR DESCRIPTION
Closes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hostname matching support with exact and case-insensitive wildcard pattern matching.
  * Invalid null hostname or pattern inputs are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->